### PR TITLE
Bump Bootstrap

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "babel-brunch": "6.1.1",
-    "bootstrap": "4.0.0",
+    "bootstrap": "4.1.2",
     "brunch": "2.10.9",
     "clean-css-brunch": "2.10.0",
     "d3": "4.5.0",


### PR DESCRIPTION
Bump Bootstrap to 4.1.2 to address [security vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2018-14041).